### PR TITLE
performance and readability refactor

### DIFF
--- a/src/gt_pro.cpp
+++ b/src/gt_pro.cpp
@@ -403,8 +403,8 @@ int main(int argc, char** argv) {
 	cerr << chrono_time() << ":  " << "[OK] Zeroing index." << endl;
 
 	// unordered_map<uint32_t, tuple<uint64_t, uint64_t>> lmer_indx;
-	constexpr uint64_t k_4_BILLION = ((uint64_t) 1) << (uint64_t) 32;
-	tuple<uint64_t, uint64_t> *lmer_indx = new tuple<uint64_t, uint64_t>[k_4_BILLION]();
+	constexpr uint64_t k_1_BILLION = ((uint64_t) 1) << (uint64_t) 30;
+	tuple<uint64_t, uint64_t> *lmer_indx = new tuple<uint64_t, uint64_t>[k_1_BILLION]();
 
 	cerr << chrono_time() << ":  " << "[OK] start to load DB: " << db_path << endl;
 
@@ -413,7 +413,7 @@ int main(int argc, char** argv) {
 
 		auto kmer_int = mmappedData[i];
 
-		uint32_t lmer_int = (uint32_t)((kmer_int & 0xFFFFFFFF00000000LL) >> 32);
+		uint32_t lmer_int = (uint32_t)((kmer_int & 0x3FFFFFFF00000000LL) >> 32);
 		uint32_t mmer_int = (uint32_t)(kmer_int & 0xFFFFFFFFLL);
 
 		mmers.push_back(mmer_int);

--- a/src/gt_pro.cpp
+++ b/src/gt_pro.cpp
@@ -129,9 +129,9 @@ void kmer_lookup(LmerRange* lmer_indx, vector<uint32_t>& mmers, vector<uint64_t>
 	constexpr uint64_t PROGRESS_UPDATE_INTERVAL = 5*1000*1000;
 
 
-    // Reads that contain wildcard characters ('N' or 'n') are split into
-    // tokens at those wildcard characters.  Each token is processed as
-    // though it were a separate read.
+	// Reads that contain wildcard characters ('N' or 'n') are split into
+	// tokens at those wildcard characters.  Each token is processed as
+	// though it were a separate read.
 	constexpr int MAX_TOKEN_LENGTH = 500;
 	constexpr int MIN_TOKEN_LENGTH = 31;
 
@@ -188,7 +188,7 @@ void kmer_lookup(LmerRange* lmer_indx, vector<uint32_t>& mmers, vector<uint64_t>
 				// The current line does *not* contain a read sequence.
 				// Next character, please.
 				continue;
-            }
+			}
 
 			// The current line contains a read sequence.  Split it into tokens at wildcard 'N'
 			// characters.  Buffer current token in seq_buf[0...MAX_READ_LENGTH-1].
@@ -259,9 +259,9 @@ void kmer_lookup(LmerRange* lmer_indx, vector<uint32_t>& mmers, vector<uint64_t>
 	}
 
 	if (token_length != 0) {
-    	cerr << chrono_time() << ":  " << "Error:  Truncated read sequence at end of file: " << in_path << endl;
+		cerr << chrono_time() << ":  " << "Error:  Truncated read sequence at end of file: " << in_path << endl;
 		exit(EXIT_FAILURE);
-    }
+	}
 
 	cerr << chrono_time() << ":  " << "[Done] searching is completed, emitting results for " << in_path << endl;
 	ofstream fh(out_path, ofstream::out | ofstream::binary);


### PR DESCRIPTION
This change reduces DB load time from 104 to 14 seconds, speeds up queries, refactors the DB loading and parsing loop for better readability and to facilitate future performance work.

* report error for truncated read sequence at EOF

* reserve memory for SNPS and MMERS arrays

* replace unordered_map with array for 3x speedup

* refactor DB loading;  correctly loads first and last lmer

It also retains the functionality of the recent improvements to wildcard handling in master.