### PR TITLE
Boris/2019 03 18

### DIFF
--- a/src/gt_pro.cpp
+++ b/src/gt_pro.cpp
@@ -64,7 +64,7 @@ using MmerType = uint32_t;
 static_assert(LMER_MASK <= numeric_limits<LmerType>::max());
 static_assert(MMER_MASK <= numeric_limits<MmerType>::max());
 
-const uint64_t MAX_PRESENT = (((uint64_t) MMER_MASK) << 2) | 0x3;
+const uint64_t MAX_PRESENT = (((uint64_t) MMER_MASK) << 4) | 0xf;
 
 // Choose appropriately sized integer types to represent offsets into
 // the array of all mmers.

--- a/src/gt_pro.cpp
+++ b/src/gt_pro.cpp
@@ -46,7 +46,7 @@ constexpr bool USE_BINARY_SEARCH = false;
 // See bit_encode
 constexpr uint8_t BITS_PER_BASE = 2;
 
-constexpr int L = 14;
+constexpr int L = 15;
 constexpr int K = 31;
 constexpr int M = K - L;
 
@@ -59,7 +59,7 @@ constexpr uint64_t MMER_MASK = (((uint64_t) 1) << (BITS_PER_BASE * M)) - 1;
 // Given L and M above, choose appropriately-sized integer types
 // to represent lmers and mmers.
 using LmerType = uint32_t;
-using MmerType = uint64_t;
+using MmerType = uint32_t;
 
 static_assert(LMER_MASK <= numeric_limits<LmerType>::max());
 static_assert(MMER_MASK <= numeric_limits<MmerType>::max());
@@ -398,8 +398,8 @@ int main(int argc, char** argv) {
 
 	for (uint64_t i = 0;  i < filesize / 8;  i += 2) {
 		auto kmer = mmappedData[i];
-		MmerType mmer = MMER_MASK & kmer; // 34 lsbs of kmer, assuming M=17
-		LmerType lmer = LMER_MASK & (kmer >> (M * BITS_PER_BASE)); // 28 msbs of kmer, assuming L=14, M=17
+		MmerType mmer = MMER_MASK & kmer;
+		LmerType lmer = LMER_MASK & (kmer >> (M * BITS_PER_BASE));
 		mmers[end] = mmer;
 		snps[end] = mmappedData[i+1];
 		if (i > 0 && lmer != last_lmer) {


### PR DESCRIPTION
This is ready to go in.   Improved RAM consumption using MMAP without affecting performance.

New command line options to play with perf params.

  -p    preload DB instead of deferring to MMAP

  -l    number of bits for L-mer;  supported values 26-30

  -m    number of bits for M-mer presence index;  supported values 30, 32, 34, 35, 36
