### PR TITLE
add second input to sckmer builddb (monospecific SNPs whitelists)

### DIFF
--- a/src/sckmerdb_build.cpp
+++ b/src/sckmerdb_build.cpp
@@ -89,13 +89,15 @@ uint64_t seq_encode(const char* buf) {
 //      $6 - reverse complement of $4
 //      $7 - unused
 //      $8 - unused
-//      $9 - 6 decimal digit species ID
-//      $10 - unused
+//      $9 - unused
+//      $10 - 6 decimal digit species ID
+//      $11 - unused
+//      $12 - unused
 //
 //  a "snp coordinate" is obtained by concatenating the following character strings and
 //  converting the result back to an integer:
 //
-//      * the 6 decimal digit species id (input column $8),
+//      * the 6 decimal digit species id (input column $10),
 //
 //      * a single digit allele type:
 //           (0 = major allele, matching input $3 and $5,


### PR DESCRIPTION
the input 'DDDDDD.sckmer_allowed.tsv' is presumed to contain a subset of the SNPs that are known to occur only in just one species

example DB build
```
    time /path/to/sckmerdb_build *.sckmer_allowed.tsv > ../db.bin
```
where
```
    ls | sort | head
    100002.sckmer_allowed.tsv
    100002.sckmer_profiles.tsv
    100003.sckmer_allowed.tsv
    100003.sckmer_profiles.tsv
    ...
```
note that the 'DDDDDD.sckmer_profiles.tsv' input is still required and will be automatically located given 'DDDDDD.sckmer_allowed.tsv' on the command line