### PR TITLE
refactor multithreading code for readability and gzip performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ sckmerdb_build: src/sckmerdb_build.cpp Makefile
 
 clean:
 	rm ./sckmerdb_build ./gt_pro
+
+reformat:
+	clang-format -style="{BasedOnStyle: llvm, ColumnLimit: 128}" src/sckmerdb_build.cpp > tmp-1.cpp && mv tmp-1.cpp src/sckmerdb_build.cpp
+	clang-format -style="{BasedOnStyle: llvm, ColumnLimit: 128}" src/gt_pro.cpp > tmp-2.cpp && mv tmp-2.cpp src/gt_pro.cpp

--- a/src/sckmerdb_build.cpp
+++ b/src/sckmerdb_build.cpp
@@ -457,9 +457,7 @@ void multi_btc64(int n_path, const char **kpaths) {
     // Hacky parallel sort, funny c++ hasn't gotten around to making this standard.
     // Cuts the sort time in half, which is a considerable part of the program's overall runtime.
     using iterator = vector<KmerData>::iterator;
-    auto sorter = [](iterator start, iterator end) {
-      sort(start, end);
-    };
+    auto sorter = [](iterator start, iterator end) { sort(start, end); };
     auto merger = [](iterator start, iterator middle, iterator end) {
       // LOL, turns out this "inplace_merge" isn't actually in-place, so it allocs tons of RAM!
       // Should do something much better here --- like parallel quicksort with depth 2.


### PR DESCRIPTION
the initial implementation worked but was a bit messy and didn't allow for multiple gzip decompression processes to run on different input files, which was limiting performance for gzipped inputs in the aws server environment

this refactor cleans it up using more C++ objects/classes

it also allows up to 8 (configurable) inputs to be gunzip'ed in parallel, which should take care of the performance issue

it would also enable multiple inputs to be fetched from s3 in parallel for higher performance

tested and ready to merge